### PR TITLE
Moved AcaiMobile Session initialization to fixed file path

### DIFF
--- a/Acai/AcaiMobile/AcaiSessionSingleton.cs
+++ b/Acai/AcaiMobile/AcaiSessionSingleton.cs
@@ -1,5 +1,4 @@
 ﻿using AcaiCore;
-using CommunityToolkit.Maui.Storage;
 
 namespace AcaiMobile
 {
@@ -7,159 +6,44 @@ namespace AcaiMobile
     {
         private static AcaiSession _session;
 
-        private const string JournalFilePathPreferencesKey = "AcaiJournalFilePath";
-
-        public static async Task<AcaiSession> Get(Page requestingPage)
+        private const string AcaiJournalFileName = "AcaiJournal.sql";
+        
+        public static async Task<AcaiSession> Get()
         {
             if (_session == null)
             {
                 await InitializeAcaiSession();
             }
-
+            
             return _session;
         }
 
-        // TODO: This whole thing generally is not great. The challenges of fighting with External Storage APIs in Android isn't worth it just to allow a journal to be saved to arbitrary paths.
-        // This should be re-written at some point to use a hard-coded path in the App Data Directory, this would create an opportunity to either use Backup APIs frameworks for the platform or add a one-time import/export utility later.
-        // https://learn.microsoft.com/en-us/dotnet/maui/platform-integration/storage/file-system-helpers
         private static async Task InitializeAcaiSession()
         {
-            var userHasPreviouslySpecifiedAJournalFilePath = Preferences.Default.ContainsKey(JournalFilePathPreferencesKey);
-            if (!userHasPreviouslySpecifiedAJournalFilePath)
+            var journalFilePath = FileSystem.AppDataDirectory + "/" + AcaiJournalFileName;
+            var sessionInitializationFacade = new SessionInitializationFacade(
+                JournalTableSchemas.All,
+                new SqliteConnectionFactory(""));
+            
+            var existingJournalInitializationIsSuccessful = sessionInitializationFacade.InitializeSessionFromExistingJournalFileAtPath(journalFilePath);
+            if (!existingJournalInitializationIsSuccessful)
             {
-                var continueWithSetup = await Shell.Current.DisplayAlert(
-                    "First-time Setup",
-                    "It looks like this is your first time using Acai on this device, would you like to set up a Journal file now?" +
-                    "\n\n" +
-                    "All entries you make into Acai will be saved to a Journal file which is kept locally on your device. If you have not created a Journal file yet, one will need to be created. " +
-                    "Alternatively, if you already have a Journal file in a cloud drive or from a different device, you can point Acai to continue using that." +
-                    "\n\n" +
-                    "Would you like to do this now? Note that this app will close if you select 'No'.",
-                    "Yes",
-                    "No");
-                
-                if (!continueWithSetup)
+                var initializationFailureReason = sessionInitializationFacade.GetInitializationFailureReason();
+                if (initializationFailureReason == SessionInitializationFailureReason.JOURNAL_FILE_DOES_NOT_EXIST)
                 {
-                    Application.Current.Quit();
-                }
-
-                var journalSetupApproach = await Shell.Current.DisplayActionSheet(
-                    "First-time Setup",
-                    "Cancel",
-                    null,
-                    "Create new Journal file",
-                    "I already have a Journal file");
-                
-                if (journalSetupApproach == null || journalSetupApproach == "Cancel")
-                {
-                    Application.Current.Quit();
-                }
-
-                var useExistingJournalFile = journalSetupApproach == "I already have a Journal file";
-                if (useExistingJournalFile)
-                {
-                    var destinationFile = await FilePicker.PickAsync(PickOptions.Default);
-                    if (destinationFile == null)
-                    {
-                        Application.Current.Quit();
-                    }
-
-                    var sessionInitializationFacade = new SessionInitializationFacade(
-                        JournalTableSchemas.All,
-                        new SqliteConnectionFactory(""));
-
-                    var sessionInitializationOutcome =
-                        sessionInitializationFacade.InitializeSessionFromExistingJournalFileAtPath(destinationFile.FullPath);
-                    if (sessionInitializationOutcome == false)
-                    {
-                        switch (sessionInitializationFacade.GetInitializationFailureReason())
-                        {
-                            case SessionInitializationFailureReason.JOURNAL_FILE_DOES_NOT_EXIST:
-                                await Shell.Current.DisplayAlert("Error", "Journal File does not exist.", "Ok");
-                                break;
-                            case SessionInitializationFailureReason.JOURNAL_FILE_IS_MISSING_TABLES:
-                                await Shell.Current.DisplayAlert("Error", "File is missing tables.", "Ok");
-                                break;
-                            case SessionInitializationFailureReason.JOURNAL_FILE_ALREADY_EXISTS:
-                                await Shell.Current.DisplayAlert("Error", "There is already a Journal file with this name at the same destination.", "Ok");
-                                break;
-                            default:
-                                await Shell.Current.DisplayAlert("Error", "Failed to create and initialize a Journal file at this destination (unknown reason).", "Ok");
-                                break;
-                        }
-                        Application.Current.Quit();
-                    }
-
-                    await Shell.Current.DisplayAlert("Done!", "Journal File set Successfully!", "Ok");
-                    Preferences.Default.Set(JournalFilePathPreferencesKey, destinationFile.FullPath);
+                    sessionInitializationFacade.InitializeSessionFromNewJournalFileAtPath(journalFilePath);
                     _session = sessionInitializationFacade.GetSession();
+                    return;
                 }
-                else
+
+                if (initializationFailureReason == SessionInitializationFailureReason.JOURNAL_FILE_HAS_BAD_TABLES)
                 {
-                    var destinationFolder = await FolderPicker.Default.PickAsync();
-                    if (!destinationFolder.IsSuccessful)
-                    {
-                        Application.Current.Quit();
-                    }
-                    
-                    var journalFileName = await Shell.Current.DisplayPromptAsync("Journal file name", "Please enter a name for your Journal file.", "Submit", "Cancel", null, -1, Keyboard.Plain, "my-acai-journal.sql");
-                    if (journalFileName == null)
-                    {
-                        Application.Current.Quit();
-                    }
-
-                    var fullJournalFilePath = destinationFolder.Folder.Path + "/" + journalFileName;
-
-                    var sessionInitializationFacade = new SessionInitializationFacade(
-                        JournalTableSchemas.All,
-                        new SqliteConnectionFactory(""));
-
-                    var sessionInitializationOutcome =
-                        sessionInitializationFacade.InitializeSessionFromNewJournalFileAtPath(fullJournalFilePath);
-                    if (sessionInitializationOutcome == false)
-                    {
-                        switch (sessionInitializationFacade.GetInitializationFailureReason())
-                        {
-                            case SessionInitializationFailureReason.JOURNAL_FILE_ALREADY_EXISTS:
-                                await Shell.Current.DisplayAlert("Error", "There is already a Journal file with this name at the same destination.", "Ok");
-                                break;
-                            default:
-                                await Shell.Current.DisplayAlert("Error", "Failed to create and initialize a Journal file at this destination (unknown reason).", "Ok");
-                                break;
-                        }
-                        Application.Current.Quit();
-                    }
-
-                    Shell.Current.DisplayAlert("Done!", "Journal created successfully!", "Ok");
-                    Preferences.Default.Set(JournalFilePathPreferencesKey,fullJournalFilePath);
-                    _session = sessionInitializationFacade.GetSession();
+                    // TODO: What should happen in the event of journal file corruption?
+                    Application.Current.Quit();
                 }
             }
-            else
-            {
-                var sessionInitializationFacade = new SessionInitializationFacade(
-                    JournalTableSchemas.All,
-                    new SqliteConnectionFactory(""));
 
-                var sessionInitializationOutcome = sessionInitializationFacade.InitializeSessionFromExistingJournalFileAtPath(Preferences.Default.Get(JournalFilePathPreferencesKey, ""));
-                if (sessionInitializationOutcome == false)
-                {
-                    switch (sessionInitializationFacade.GetInitializationFailureReason())
-                    {
-                        case SessionInitializationFailureReason.JOURNAL_FILE_DOES_NOT_EXIST:
-                            await Shell.Current.DisplayAlert("Unable to initialize Session from existing file", $"File does not exist. {Preferences.Default.Get(JournalFilePathPreferencesKey,"")}", "Ok");
-                            break;
-                        case SessionInitializationFailureReason.JOURNAL_FILE_IS_MISSING_TABLES:
-                            await Shell.Current.DisplayAlert("Unable to initialize Session from existing file", "Journal file is missing tables, corruption likely.", "Ok");
-                            break;
-                        default:
-                            await Shell.Current.DisplayAlert("Unable to initialize Session from existing file", "Unknown reason.", "Ok");
-                            break;
-                    }
-                    Application.Current.Quit();
-                }
-                _session = sessionInitializationFacade.GetSession();
-            }
+            _session = sessionInitializationFacade.GetSession();
         }
     }
 }

--- a/Acai/AcaiMobile/FoodJournalViewModel.cs
+++ b/Acai/AcaiMobile/FoodJournalViewModel.cs
@@ -39,7 +39,7 @@ public partial class FoodJournalViewModel : ObservableObject
         {
             if (newItemPage.HasBeenSubmitted())
             {
-                var session = await AcaiSessionSingleton.Get(Shell.Current.CurrentPage);
+                var session = await AcaiSessionSingleton.Get();
                 var newItemDto = session.GetFoodItemGateway().CreateNewFoodItem(newItemPage.GetSubmittedItemName(), newItemPage.GetSubmittedItemCalories(), newItemPage.GetSubmittedItemCreationDate());
                 ReinitializeFoodItemList();
         
@@ -56,7 +56,7 @@ public partial class FoodJournalViewModel : ObservableObject
         var itemPendingDeletion = _foodItemsList.FirstOrDefault(x => x.Id == itemId.Id);
         if (itemPendingDeletion != null)
         {
-            var session = await AcaiSessionSingleton.Get(Shell.Current.CurrentPage);
+            var session = await AcaiSessionSingleton.Get();
             session.GetFoodItemGateway().DeleteFoodItem(itemPendingDeletion.Id);
             _foodItemsList.Remove(itemPendingDeletion);
         }
@@ -101,7 +101,7 @@ public partial class FoodJournalViewModel : ObservableObject
     private async void ReinitializeFoodItemList()
     {
         _foodItemsList.Clear();
-        var session = await AcaiSessionSingleton.Get(Shell.Current.CurrentPage);
+        var session = await AcaiSessionSingleton.Get();
         foreach (var foodItem in session.GetFoodItemGateway().GetFoodItemsForDate(_selectedDate))
         {
             _foodItemsList.Add(new FoodJournalViewItem(foodItem));

--- a/Acai/AcaiMobile/NewItemViewModel.cs
+++ b/Acai/AcaiMobile/NewItemViewModel.cs
@@ -32,7 +32,7 @@ public partial class NewItemViewModel : ObservableObject
 
     public NewItemViewModel()
     {
-        var session = AcaiSessionSingleton.Get(null).Result;
+        var session = AcaiSessionSingleton.Get().Result;
         _allFoodItemShortcuts = new List<FoodItemViewShortcut>();
         foreach (var shortcut in session.GetFoodItemShortcutGateway().GetAllFoodItemShortcuts())
         {


### PR DESCRIPTION
After further consideration following a period of dog-fooding a build of AcaiMobile and testing on older Android devices, the value of allowing a user to determine where a Journal file is saved during app usage is not worth the considerations that need to be given to things such as Android Storage APIs and the permissions surrounding individual locations chosen by a user. 

Because of this, AcaiSessionSingleton has been updated to initialize sessions from a fixed file path relative to the App Data Directory helper exposed by .NET MAUI. This is expected to prevent the issues observed during testing and has the potential added benefit of allowing Android's Auto Backup API to be utilized: https://learn.microsoft.com/en-us/dotnet/maui/platform-integration/storage/file-system-helpers