### PR TITLE
Added display of Application Version to Settings Page.

### DIFF
--- a/Acai/AcaiMobile/AcaiMobile.csproj
+++ b/Acai/AcaiMobile/AcaiMobile.csproj
@@ -18,8 +18,8 @@
 		<ApplicationIdGuid>676b8ee5-cc89-4f39-a40a-0cddcf8edde8</ApplicationIdGuid>
 
 		<!-- Versions -->
-		<ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
-		<ApplicationVersion>1</ApplicationVersion>
+		<ApplicationDisplayVersion>V1.0.1</ApplicationDisplayVersion>
+		<ApplicationVersion>100</ApplicationVersion>
 
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">14.0</SupportedOSPlatformVersion>

--- a/Acai/AcaiMobile/Pages/SettingsPage/SettingsPage.xaml
+++ b/Acai/AcaiMobile/Pages/SettingsPage/SettingsPage.xaml
@@ -115,6 +115,20 @@
                     </Switch>
                 </Grid>
 
+                <!-- About / Version Info -->
+                <Label Style="{StaticResource H1}" Text="About"></Label>
+            
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                
+                    <StackLayout Grid.Column="0">
+                        <Label Style="{StaticResource H2}" Text="Version" HorizontalTextAlignment="Start"></Label>
+                        <Label Text="{Binding VersionString}"></Label>
+                    </StackLayout>
+                </Grid>
             </VerticalStackLayout>
         </ScrollView>
     </ContentPage.Content>

--- a/Acai/AcaiMobile/Pages/SettingsPage/SettingsPageViewModel.cs
+++ b/Acai/AcaiMobile/Pages/SettingsPage/SettingsPageViewModel.cs
@@ -22,6 +22,9 @@ public partial class SettingsPageViewModel : ObservableObject
     
     [ObservableProperty]
     private bool _displayWater = Preferences.Get(PreferenceIndex.DisplayWater.Key, PreferenceIndex.DisplayWater.DefaultValue);
+
+    [ObservableProperty] 
+    private string _versionString = AppInfo.VersionString;
     
     [RelayCommand]
     private async void UpdateDailyCaloricLimitSetting()


### PR DESCRIPTION
This PR adds a setting to the Settings Page on AcaiMobile which shows the Version number of the app when built, allowing the installed version of an app to be compared against future versions.