### PR TITLE
AcaiMobile: Added user-toggleable confirmation dialog when discarding Food Journal item changes

### DIFF
--- a/Acai/AcaiMobile/Pages/ItemEditorPage/ItemEditorPage.xaml.cs
+++ b/Acai/AcaiMobile/Pages/ItemEditorPage/ItemEditorPage.xaml.cs
@@ -7,6 +7,12 @@ public partial class ItemEditorPage : TabbedPage
         InitializeComponent();
         BindingContext = new ItemEditorViewModel();
     }
+
+    protected override bool OnBackButtonPressed()
+    {
+        ((ItemEditorViewModel)BindingContext).OnBackButtonPressed();
+        return true;
+    }
     
     public void PopulateFields(string name, float calories, DateTime creationDate, float? protein, float? carbohydrates, float? fat, float? fibre, float? water)
     {

--- a/Acai/AcaiMobile/Pages/ItemEditorPage/ItemEditorViewModel.cs
+++ b/Acai/AcaiMobile/Pages/ItemEditorPage/ItemEditorViewModel.cs
@@ -69,6 +69,37 @@ public partial class ItemEditorViewModel : ObservableObject
         }
         DisplayAllFoodItemShortcutsInResults();
     }
+
+    public async Task<bool> OnBackButtonPressed()
+    {
+        var skipDiscardConfirmation = Preferences.Get(PreferenceIndex.WarnBeforeDiscardingFoodItemChanges.Key, PreferenceIndex.WarnBeforeDiscardingFoodItemChanges.DefaultValue) == false;
+        if (skipDiscardConfirmation || !FormIsDirty())
+        {
+            Shell.Current.Navigation.PopModalAsync(true);
+            return true;
+        }
+        
+        var userHasConfirmedDismissal = await Shell.Current.DisplayAlert("Are you sure?", "Discard Incomplete Changes?", "Yes", "No");
+        if (userHasConfirmedDismissal)
+        {
+            Shell.Current.Navigation.PopModalAsync(true);
+        }
+        return true;
+    }
+
+    private bool FormIsDirty()
+    {
+        if (NewItemName != string.Empty) { return true; }
+        if (NewItemCalories != 0) { return true; }
+        if (NewItemCreationDate.Date != DateTime.Now.Date) { return true; }
+        if (NewItemProtein != null) { return true; }
+        if (NewItemCarbohydrates != null) { return true; }
+        if (NewItemFat != null) { return true; }
+        if (NewItemFibre != null) { return true; }
+        if (NewItemWater != null) { return true; }
+        if (CreateNewFoodItemShortcut) { return true; }
+        return false;
+    }
     
     [RelayCommand]
     private void ValidateNewItemDetails()

--- a/Acai/AcaiMobile/Pages/SettingsPage/SettingsPage.xaml
+++ b/Acai/AcaiMobile/Pages/SettingsPage/SettingsPage.xaml
@@ -28,6 +28,27 @@
                     <Button Grid.Column="1" Text="Update" Command="{Binding UpdateDailyCaloricLimitSettingCommand}"></Button>
                 </Grid>
                 
+                <!-- Food Journal -->
+                <Label Style="{StaticResource H1}" Text="Food Journal"></Label>
+                
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    
+                    <VerticalStackLayout Grid.Column="0">
+                        <Label Style="{StaticResource H2}" Text="Warn Before Discarding Item Changes" HorizontalTextAlignment="Start"></Label>
+                        <Label Text="Display a confirmation dialog before discarding unsaved changes when editing a Food Journal Item."></Label>
+                    </VerticalStackLayout>
+                    <Switch Grid.Column="1" IsToggled="{Binding WarnBeforeDiscardingFoodItemChanges}">
+                        <Switch.Behaviors>
+                            <toolkit:EventToCommandBehavior EventName="Toggled" Command="{Binding UpdateWarningBeforeDiscardingFoodItemChangesCommand}"/>
+                        </Switch.Behaviors>
+                    </Switch>
+                </Grid>
+                
+                <!-- Macronutrients -->
                 <Label Style="{StaticResource H1}" Text="Macronutrients"></Label>
                 
                 <Grid>

--- a/Acai/AcaiMobile/Pages/SettingsPage/SettingsPageViewModel.cs
+++ b/Acai/AcaiMobile/Pages/SettingsPage/SettingsPageViewModel.cs
@@ -9,6 +9,9 @@ public partial class SettingsPageViewModel : ObservableObject
     private float _dailyCaloricLimit = Preferences.Get(PreferenceIndex.DailyCaloricLimit.Key, PreferenceIndex.DailyCaloricLimit.DefaultValue);
     
     [ObservableProperty]
+    private bool _warnBeforeDiscardingFoodItemChanges = Preferences.Get(PreferenceIndex.WarnBeforeDiscardingFoodItemChanges.Key, PreferenceIndex.WarnBeforeDiscardingFoodItemChanges.DefaultValue);
+    
+    [ObservableProperty]
     private bool _displayProtein = Preferences.Get(PreferenceIndex.DisplayProtein.Key, PreferenceIndex.DisplayProtein.DefaultValue);
     
     [ObservableProperty]
@@ -37,6 +40,12 @@ public partial class SettingsPageViewModel : ObservableObject
         }
     }
 
+    [RelayCommand]
+    private void UpdateWarningBeforeDiscardingFoodItemChanges()
+    {
+        Preferences.Set(PreferenceIndex.WarnBeforeDiscardingFoodItemChanges.Key, WarnBeforeDiscardingFoodItemChanges);
+    }
+    
     [RelayCommand]
     private void UpdateProteinVisibility()
     {

--- a/Acai/AcaiMobile/PreferenceIndex.cs
+++ b/Acai/AcaiMobile/PreferenceIndex.cs
@@ -9,6 +9,7 @@ public readonly struct PreferencesKeyDefaultValuePair<T>(string key, T defaultVa
 public static class PreferenceIndex
 {
     public static readonly PreferencesKeyDefaultValuePair<float> DailyCaloricLimit = new("dailyCaloricLimit", 2000.0f);
+    public static readonly PreferencesKeyDefaultValuePair<bool> WarnBeforeDiscardingFoodItemChanges = new("warnBeforeDiscardingFoodItemChanges", true);
     public static readonly PreferencesKeyDefaultValuePair<bool> DisplayProtein = new("displayProtein", true);
     public static readonly PreferencesKeyDefaultValuePair<bool> DisplayCarbohydrates = new("displayCarbohydrates", true);
     public static readonly PreferencesKeyDefaultValuePair<bool> DisplayFat = new("displayFat", true);


### PR DESCRIPTION
This PR introduces behavior to AcaiMobile which displays a confirmation dialog to the User when attempting to back out of the Item Details modal when editing / creating a Food Journal item, protecting them from losing changes accidentally during editing.

This behavior can be enabled or disabled at the user's descretion via a new "Warn Before Discarding Item Changes" toggle provided via the Settings page.