### PR TITLE
Added Editable Note to Food Journal Page

### DIFF
--- a/Acai/AcaiCore/FoodJournalNoteGateway/FoodJournalNoteGateway.cs
+++ b/Acai/AcaiCore/FoodJournalNoteGateway/FoodJournalNoteGateway.cs
@@ -1,4 +1,6 @@
-﻿namespace AcaiCore;
+﻿using Microsoft.Data.Sqlite;
+
+namespace AcaiCore;
 
 public class FoodJournalNoteGateway : IFoodJournalNoteGateway
 {
@@ -11,7 +13,89 @@ public class FoodJournalNoteGateway : IFoodJournalNoteGateway
     
     public FoodJournalNoteDTO CreateOrUpdateNoteForDate(DateTime date, string content)
     {
-        throw new NotImplementedException();
+        long createdNoteId = -1;
+        DateTime createdNoteDate = DateTime.MinValue;
+        string createdNoteContent = string.Empty;
+
+        using (var connection = sqliteConnectionFactory.CreateOpenConnection())
+        {
+            using (var checkExistingNoteCommand = connection.CreateCommand())
+            {
+                checkExistingNoteCommand.CommandText = "SELECT id FROM food_journal_notes WHERE date = @noteDate LIMIT 1;";
+
+                var noteDateParameter = new SqliteParameter("@noteDate", date);
+                noteDateParameter.Value = date.ToString("yyyy-MM-dd");
+                checkExistingNoteCommand.Parameters.Add(noteDateParameter);
+                
+                var existingNoteId = checkExistingNoteCommand.ExecuteScalar();
+                if (existingNoteId != null)
+                {
+                    createdNoteId = (long)existingNoteId;
+                }
+            }
+
+            var noteAlreadyExistsForDate = createdNoteId != -1;
+
+            if (!noteAlreadyExistsForDate)
+            {
+                using (var insertCommand = connection.CreateCommand())
+                {
+                    insertCommand.CommandText = "INSERT INTO food_journal_notes (date, content) VALUES (@noteDate, @noteContent) RETURNING id;";
+                
+                    var noteContentParameter = new SqliteParameter("@noteContent",SqliteType.Text);
+                    noteContentParameter.Value = content;
+                    
+                    var noteDateParameter = new SqliteParameter("@noteDate",SqliteType.Text);
+                    noteDateParameter.Value = date.ToString("yyyy-MM-dd");
+                
+                    insertCommand.Parameters.AddRange(new List<SqliteParameter>()
+                    {
+                        noteContentParameter,
+                        noteDateParameter
+                    });
+                    insertCommand.Prepare();
+                
+                    createdNoteId = (long)insertCommand.ExecuteScalar();
+                }
+            }
+            else
+            {
+                using (var updateCommand = connection.CreateCommand())
+                {
+                    updateCommand.CommandText = "UPDATE food_journal_notes SET (content) = (@noteContent) WHERE id = @noteId;";
+                    
+                    var noteIdParameter = new SqliteParameter("@noteId",SqliteType.Real);
+                    noteIdParameter.Value = createdNoteId;
+                    
+                    var noteContentParameter = new SqliteParameter("@noteContent",SqliteType.Text);
+                    noteContentParameter.Value = content;
+                    
+                    updateCommand.Parameters.AddRange(new List<SqliteParameter>()
+                    {
+                        noteIdParameter,
+                        noteContentParameter
+                    });
+                    updateCommand.Prepare();
+                    updateCommand.ExecuteNonQuery();
+                }
+            }
+
+            using (var selectNewNoteCommand = connection.CreateCommand())
+            {
+                selectNewNoteCommand.CommandText = $"SELECT date, content FROM food_journal_notes WHERE id = {createdNoteId} LIMIT 1;";
+
+                using (var reader = selectNewNoteCommand.ExecuteReader())
+                {
+                    while (reader.Read())
+                    {
+                        createdNoteDate = reader.GetDateTime(0);
+                        createdNoteContent = reader.GetString(1);
+                    }
+                }
+            }
+        }
+
+        return new FoodJournalNoteDTO(1,createdNoteDate,createdNoteContent);
     }
 
     public FoodJournalNoteDTO? GetNoteForDate(DateTime date)

--- a/Acai/AcaiCore/FoodJournalNoteGateway/FoodJournalNoteGateway.cs
+++ b/Acai/AcaiCore/FoodJournalNoteGateway/FoodJournalNoteGateway.cs
@@ -1,0 +1,42 @@
+﻿namespace AcaiCore;
+
+public class FoodJournalNoteGateway : IFoodJournalNoteGateway
+{
+    private ISqliteConnectionFactory sqliteConnectionFactory;
+
+    public FoodJournalNoteGateway(ISqliteConnectionFactory connectionFactory)
+    {
+        this.sqliteConnectionFactory = connectionFactory;
+    }
+    
+    public FoodJournalNoteDTO CreateOrUpdateNoteForDate(DateTime date, string content)
+    {
+        throw new NotImplementedException();
+    }
+
+    public FoodJournalNoteDTO? GetNoteForDate(DateTime date)
+    {
+        FoodJournalNoteDTO? note = null;
+        
+        using (var connection = sqliteConnectionFactory.CreateOpenConnection())
+        {
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText = $"SELECT id, date, content FROM food_journal_notes WHERE date(date) = date('{date.ToString("yyyy-MM-dd")}');";
+                using (var reader = command.ExecuteReader())
+                {
+                    while (reader.Read())
+                    {
+                        long noteId = reader.GetInt64(0);
+                        DateTime noteDate = reader.GetDateTime(1);
+                        string noteContent = reader.GetString(2);
+                        
+                        note = new FoodJournalNoteDTO(noteId, noteDate, noteContent);
+                    }
+                }
+            }
+        }
+        
+        return note;
+    }
+}

--- a/Acai/AcaiCore/FoodJournalNoteGateway/IFoodJournalNoteGateway.cs
+++ b/Acai/AcaiCore/FoodJournalNoteGateway/IFoodJournalNoteGateway.cs
@@ -1,0 +1,37 @@
+namespace AcaiCore;
+
+public interface IFoodJournalNoteGateway
+{
+    public void CreateNoteForDate(DateTime date, string content);
+    public void UpdateNote(long id, DateTime date, string content);
+    public FoodJournalNoteDTO? GetNoteForDate(DateTime date);
+}
+
+public class FoodJournalNoteDTO
+{
+    private readonly long _id;
+    private readonly DateTime _date;
+    private readonly string _content;
+
+    public FoodJournalNoteDTO(long id, DateTime date, string content)
+    {
+        _id = id;
+        _date = date;
+        _content = content;
+    }
+
+    public long GetID()
+    {
+        return _id;
+    }
+
+    public DateTime GetDate()
+    {
+        return _date;
+    }
+
+    public string GetContent()
+    {
+        return _content;
+    }
+}

--- a/Acai/AcaiCore/FoodJournalNoteGateway/IFoodJournalNoteGateway.cs
+++ b/Acai/AcaiCore/FoodJournalNoteGateway/IFoodJournalNoteGateway.cs
@@ -2,8 +2,7 @@ namespace AcaiCore;
 
 public interface IFoodJournalNoteGateway
 {
-    public FoodJournalNoteDTO CreateNoteForDate(DateTime date, string content);
-    public FoodJournalNoteDTO UpdateNote(long id, DateTime date, string content);
+    public FoodJournalNoteDTO CreateOrUpdateNoteForDate(DateTime date, string content);
     public FoodJournalNoteDTO? GetNoteForDate(DateTime date);
 }
 

--- a/Acai/AcaiCore/FoodJournalNoteGateway/IFoodJournalNoteGateway.cs
+++ b/Acai/AcaiCore/FoodJournalNoteGateway/IFoodJournalNoteGateway.cs
@@ -2,8 +2,8 @@ namespace AcaiCore;
 
 public interface IFoodJournalNoteGateway
 {
-    public void CreateNoteForDate(DateTime date, string content);
-    public void UpdateNote(long id, DateTime date, string content);
+    public FoodJournalNoteDTO CreateNoteForDate(DateTime date, string content);
+    public FoodJournalNoteDTO UpdateNote(long id, DateTime date, string content);
     public FoodJournalNoteDTO? GetNoteForDate(DateTime date);
 }
 

--- a/Acai/AcaiCore/JournalTableSchemas/FoodJournalNotesTableSchema.cs
+++ b/Acai/AcaiCore/JournalTableSchemas/FoodJournalNotesTableSchema.cs
@@ -1,0 +1,82 @@
+using Microsoft.Data.Sqlite;
+
+namespace AcaiCore
+{
+    public class FoodJournalNotesTableSchema : IJournalTableSchema
+    {
+        private readonly string creationQuery = "CREATE TABLE \"food_journal_notes\" (\"id\" INTEGER NOT NULL UNIQUE,\"date\" TEXT NOT NULL UNIQUE,\"content\" TEXT NOT NULL, PRIMARY KEY(\"id\" AUTOINCREMENT))";
+        public string GetSQLTableCreationQuery()
+        {
+            return creationQuery;
+        }
+
+        public bool PresentInConnection(SqliteConnection sqliteConnection)
+        {
+            var idColumnIsPresent = false;
+            var dateColumnIsPresent = false;
+            var contentColumnIsPresent = false;
+            
+            using (var selectTableCommand = sqliteConnection.CreateCommand())
+            {
+                selectTableCommand.CommandText = "PRAGMA TABLE_INFO(food_journal_notes);";
+                using (var reader = selectTableCommand.ExecuteReader())
+                {
+                    while (reader.Read())
+                    {
+                        if (!idColumnIsPresent && IDColumnIsPresentInSchema(reader))
+                        {
+                            idColumnIsPresent = true;
+                            continue;
+                        }
+                        
+                        if (!dateColumnIsPresent && DateColumnIsPresentInSchema(reader))
+                        {
+                            dateColumnIsPresent = true;
+                            continue;
+                        }
+                        
+                        if (!contentColumnIsPresent && ContentColumnIsPresentInSchema(reader))
+                        {
+                            contentColumnIsPresent = true;
+                        }
+                    }
+                }
+            }
+
+            return idColumnIsPresent && dateColumnIsPresent && contentColumnIsPresent;
+        }
+
+        private bool IDColumnIsPresentInSchema(SqliteDataReader reader)
+        {
+            if (reader.GetInt64(0) != 0) return false; // cid
+            if (reader.GetString(1) != "id") return false; // name
+            if (reader.GetString(2) != "INTEGER") return false; // type
+            if (reader.GetInt64(3) != 1) return false; // notnull
+            if (reader.GetInt64(5) != 1) return false; // pk
+
+            return true;
+        }
+        
+        private bool DateColumnIsPresentInSchema(SqliteDataReader reader)
+        {
+            if (reader.GetInt64(0) != 1) return false; // cid
+            if (reader.GetString(1) != "date") return false; // name
+            if (reader.GetString(2) != "TEXT") return false; // type
+            if (reader.GetInt64(3) != 1) return false; // notnull
+            if (reader.GetInt64(5) != 0) return false; // pk
+
+            return true;
+        }
+        
+        private bool ContentColumnIsPresentInSchema(SqliteDataReader reader)
+        {
+            if (reader.GetInt64(0) != 2) return false; // cid
+            if (reader.GetString(1) != "content") return false; // name
+            if (reader.GetString(2) != "TEXT") return false; // type
+            if (reader.GetInt64(3) != 1) return false; // notnull
+            if (reader.GetInt64(5) != 0) return false; // pk
+
+            return true;
+        }
+    }
+}

--- a/Acai/AcaiCore/JournalTableSchemas/JournalTableSchemas.cs
+++ b/Acai/AcaiCore/JournalTableSchemas/JournalTableSchemas.cs
@@ -7,6 +7,7 @@ public class JournalTableSchemas
         new FoodItemTableSchema(),
         new FoodItemShortcutTableSchema(),
         new FoodItemMacronutrientsSchema(),
-        new FoodItemShortcutMacronutrientsSchema()
+        new FoodItemShortcutMacronutrientsSchema(),
+        new FoodJournalNotesTableSchema()
     };
 }

--- a/Acai/AcaiCore/SessionInitializationFacade/AcaiSession.cs
+++ b/Acai/AcaiCore/SessionInitializationFacade/AcaiSession.cs
@@ -4,11 +4,13 @@
     {
         private readonly IFoodItemGateway _foodItemGateway;
         private readonly IFoodItemShortcutGateway _foodItemShortcutGateway;
+        private readonly IFoodJournalNoteGateway _foodJournalNoteGateway;
 
-        public AcaiSession(IFoodItemGateway foodItemGateway, IFoodItemShortcutGateway foodItemShortcutGateway)
+        public AcaiSession(IFoodItemGateway foodItemGateway, IFoodItemShortcutGateway foodItemShortcutGateway, IFoodJournalNoteGateway foodJournalNoteGateway)
         {
             _foodItemGateway = foodItemGateway;
             _foodItemShortcutGateway = foodItemShortcutGateway;
+            _foodJournalNoteGateway = foodJournalNoteGateway;
         }
 
         public IFoodItemGateway GetFoodItemGateway()
@@ -19,6 +21,11 @@
         public IFoodItemShortcutGateway GetFoodItemShortcutGateway()
         {
             return _foodItemShortcutGateway;
+        }
+
+        public IFoodJournalNoteGateway GetFoodJournalNoteGateway()
+        {
+            return _foodJournalNoteGateway;
         }
     }
 }

--- a/Acai/AcaiCore/SessionInitializationFacade/SessionInitializationFacade.cs
+++ b/Acai/AcaiCore/SessionInitializationFacade/SessionInitializationFacade.cs
@@ -38,7 +38,7 @@ namespace AcaiCore
                 }
             }
 
-            _session = new AcaiSession(new FoodItemGateway(_sqliteConnectionFactory), new FoodItemShortcutGateway(_sqliteConnectionFactory));
+            _session = new AcaiSession(new FoodItemGateway(_sqliteConnectionFactory), new FoodItemShortcutGateway(_sqliteConnectionFactory), new FoodJournalNoteGateway(_sqliteConnectionFactory));
 
             return true;
         }
@@ -75,7 +75,7 @@ namespace AcaiCore
                 }
             }
 
-            _session = new AcaiSession(new FoodItemGateway(_sqliteConnectionFactory), new FoodItemShortcutGateway(_sqliteConnectionFactory));
+            _session = new AcaiSession(new FoodItemGateway(_sqliteConnectionFactory), new FoodItemShortcutGateway(_sqliteConnectionFactory), new FoodJournalNoteGateway(_sqliteConnectionFactory));
 
             return true;
         }

--- a/Acai/AcaiCoreTests/FoodJournalNoteGateway/WhenAFoodJournalNoteForAParticularDateIsRetrieved.cs
+++ b/Acai/AcaiCoreTests/FoodJournalNoteGateway/WhenAFoodJournalNoteForAParticularDateIsRetrieved.cs
@@ -1,0 +1,51 @@
+﻿using AcaiCore;
+using NUnit.Framework;
+
+namespace AcaiCoreTests.FoodJournalNoteGateway;
+
+[TestFixture]
+public class WhenAFoodJournalNoteForAParticularDateIsRetrieved
+{
+    private FoodJournalNoteDTO? _result;
+
+    [OneTimeSetUp]
+    public void Setup()
+    {
+        var connectionFactory = new TestingSqliteConnectionFactory();
+        using (var connection = connectionFactory.CreateOpenConnection())
+        {
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText = new FoodJournalNotesTableSchema().GetSQLTableCreationQuery();
+                command.ExecuteNonQuery();
+                
+                command.CommandText = "INSERT INTO food_journal_notes (id, date, content) VALUES " +
+                                      "(3, '2025-06-17', 'Test note content with **bold** and *italic* formatting.')";
+                command.ExecuteNonQuery();
+            }
+        }
+        
+        var subject = new AcaiCore.FoodJournalNoteGateway(connectionFactory);
+        _result = subject.GetNoteForDate(new DateTime(2025, 6, 17));
+    }
+
+    [Test]
+    public void ThenAnIDForTheNewItemIsReturned()
+    {
+        Assert.That(_result.GetID(), Is.EqualTo(3));
+    }
+    
+    [Test]
+    public void ThenTheCorrectContentIsReturned()
+    {
+        Assert.That(_result.GetContent(), Is.EqualTo("Test note content with **bold** and *italic* formatting."));
+    }
+
+    [Test]
+    public void ThenTheCorrectDateIsReturned()
+    {
+        Assert.That(_result.GetDate().Year, Is.EqualTo(2025));
+        Assert.That(_result.GetDate().Month, Is.EqualTo(6));
+        Assert.That(_result.GetDate().Day, Is.EqualTo(17));
+    }
+}

--- a/Acai/AcaiCoreTests/FoodJournalNoteGateway/WhenAFoodJournalNoteForAParticularDateIsRetrievedThatDoesNotExist.cs
+++ b/Acai/AcaiCoreTests/FoodJournalNoteGateway/WhenAFoodJournalNoteForAParticularDateIsRetrievedThatDoesNotExist.cs
@@ -1,0 +1,33 @@
+﻿using AcaiCore;
+using NUnit.Framework;
+
+namespace AcaiCoreTests.FoodJournalNoteGateway;
+
+[TestFixture]
+public class WhenAFoodJournalNoteForAParticularDateIsRetrievedThatDoesNotExist
+{
+    private FoodJournalNoteDTO? _result;
+
+    [OneTimeSetUp]
+    public void Setup()
+    {
+        var connectionFactory = new TestingSqliteConnectionFactory();
+        using (var connection = connectionFactory.CreateOpenConnection())
+        {
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText = new FoodJournalNotesTableSchema().GetSQLTableCreationQuery();
+                command.ExecuteNonQuery();
+            }
+        }
+        
+        var subject = new AcaiCore.FoodJournalNoteGateway(connectionFactory);
+        _result = subject.GetNoteForDate(new DateTime(2025, 6, 17));
+    }
+
+    [Test]
+    public void ThenNullIsReturned()
+    {
+        Assert.That(_result, Is.Null);
+    }
+}

--- a/Acai/AcaiCoreTests/FoodJournalNoteGateway/WhenANewFoodJournalNoteIsCreatedForADate.cs
+++ b/Acai/AcaiCoreTests/FoodJournalNoteGateway/WhenANewFoodJournalNoteIsCreatedForADate.cs
@@ -1,0 +1,47 @@
+using AcaiCore;
+using NUnit.Framework;
+
+namespace AcaiCoreTests.FoodJournalNoteGateway;
+
+[TestFixture]
+public class WhenANewFoodJournalNoteIsCreatedForADate
+{
+    private FoodJournalNoteDTO _result;
+
+    [OneTimeSetUp]
+    public void Setup()
+    {
+        var connectionFactory = new TestingSqliteConnectionFactory();
+        using (var connection = connectionFactory.CreateOpenConnection())
+        {
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText = new FoodJournalNotesTableSchema().GetSQLTableCreationQuery();
+                command.ExecuteNonQuery();
+            }
+        }
+        
+        var subject = new AcaiCore.FoodJournalNoteGateway(connectionFactory);
+        _result = subject.CreateOrUpdateNoteForDate(new DateTime(2025, 6, 20), "This is a test note for today's food journal.");
+    }
+
+    [Test]
+    public void ThenAnIDForTheNewNoteIsReturned()
+    {
+        Assert.That(_result.GetID(), Is.EqualTo(1));
+    }
+    
+    [Test]
+    public void ThenTheCorrectContentIsReturned()
+    {
+        Assert.That(_result.GetContent(), Is.EqualTo("This is a test note for today's food journal."));
+    }
+
+    [Test]
+    public void ThenTheCorrectDateIsReturned()
+    {
+        Assert.That(_result.GetDate().Year, Is.EqualTo(2025));
+        Assert.That(_result.GetDate().Month, Is.EqualTo(6));
+        Assert.That(_result.GetDate().Day, Is.EqualTo(20));
+    }
+}

--- a/Acai/AcaiCoreTests/FoodJournalNoteGateway/WhenANewFoodJournalNoteIsCreatedWithEscapableCharactersInTheContent.cs
+++ b/Acai/AcaiCoreTests/FoodJournalNoteGateway/WhenANewFoodJournalNoteIsCreatedWithEscapableCharactersInTheContent.cs
@@ -1,0 +1,32 @@
+using AcaiCore;
+using NUnit.Framework;
+
+namespace AcaiCoreTests.FoodJournalNoteGateway;
+
+[TestFixture]
+public class WhenANewFoodJournalNoteIsCreatedWithEscapableCharactersInTheContent
+{
+    
+    [TestCase("Note with 'single quotes' in the content")]
+    [TestCase("Note with \"double quotes\" in the content")]  
+    [TestCase("Note with a percentage % symbol in the content")]
+    public void ThenTheContentIsStoredAndRetrievedCorrectly(string contentWithEscapableCharacters)
+    {
+        var connectionFactory = new TestingSqliteConnectionFactory();
+        using (var connection = connectionFactory.CreateOpenConnection())
+        {
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText = new FoodJournalNotesTableSchema().GetSQLTableCreationQuery();
+                command.ExecuteNonQuery();
+            }
+        }
+        
+        var subject = new AcaiCore.FoodJournalNoteGateway(connectionFactory);
+        var result = subject.CreateOrUpdateNoteForDate(new DateTime(2025, 6, 20), contentWithEscapableCharacters);
+        
+        Assert.That(result.GetContent(), Is.EqualTo(contentWithEscapableCharacters));
+        Assert.That(result.GetID(), Is.EqualTo(1));
+        Assert.That(result.GetDate().Date, Is.EqualTo(new DateTime(2025, 6, 20).Date));
+    }
+}

--- a/Acai/AcaiCoreTests/FoodJournalNoteGateway/WhenAnExistingFoodJournalNoteIsUpdatedForADate.cs
+++ b/Acai/AcaiCoreTests/FoodJournalNoteGateway/WhenAnExistingFoodJournalNoteIsUpdatedForADate.cs
@@ -1,0 +1,53 @@
+using AcaiCore;
+using NUnit.Framework;
+
+namespace AcaiCoreTests.FoodJournalNoteGateway;
+
+[TestFixture]
+public class WhenAnExistingFoodJournalNoteIsUpdatedForADate
+{
+    private FoodJournalNoteDTO _result;
+    private int _originalNoteId;
+
+    [OneTimeSetUp]
+    public void Setup()
+    {
+        var connectionFactory = new TestingSqliteConnectionFactory();
+        using (var connection = connectionFactory.CreateOpenConnection())
+        {
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText = new FoodJournalNotesTableSchema().GetSQLTableCreationQuery();
+                command.ExecuteNonQuery();
+                
+                command.CommandText = "INSERT INTO food_journal_notes (id, date, content) VALUES " +
+                                      "(1, '2025-06-20', 'Original note content.')";
+                command.ExecuteNonQuery();
+                _originalNoteId = 1;
+            }
+        }
+        
+        var subject = new AcaiCore.FoodJournalNoteGateway(connectionFactory);
+        _result = subject.CreateOrUpdateNoteForDate(new DateTime(2025, 6, 20), "Updated note content with new information.");
+    }
+
+    [Test]
+    public void ThenTheSameIDAsTheOriginalNoteIsReturned()
+    {
+        Assert.That(_result.GetID(), Is.EqualTo(_originalNoteId));
+    }
+    
+    [Test]
+    public void ThenTheUpdatedContentIsReturned()
+    {
+        Assert.That(_result.GetContent(), Is.EqualTo("Updated note content with new information."));
+    }
+
+    [Test]
+    public void ThenTheCorrectDateIsReturned()
+    {
+        Assert.That(_result.GetDate().Year, Is.EqualTo(2025));
+        Assert.That(_result.GetDate().Month, Is.EqualTo(6));
+        Assert.That(_result.GetDate().Day, Is.EqualTo(20));
+    }
+}

--- a/Acai/AcaiCoreTests/FoodJournalNoteGateway/WhenAnExistingFoodJournalNoteIsUpdatedWithEscapableCharactersInTheContent.cs
+++ b/Acai/AcaiCoreTests/FoodJournalNoteGateway/WhenAnExistingFoodJournalNoteIsUpdatedWithEscapableCharactersInTheContent.cs
@@ -1,0 +1,36 @@
+using AcaiCore;
+using NUnit.Framework;
+
+namespace AcaiCoreTests.FoodJournalNoteGateway;
+
+[TestFixture]
+public class WhenAnExistingFoodJournalNoteIsUpdatedWithEscapableCharactersInTheContent
+{
+    
+    [TestCase("Updated note with 'single quotes' in content")]
+    [TestCase("Updated note with \"double quotes\" in content")]  
+    [TestCase("Updated note with a percentage % symbol in content")]
+    public void ThenTheContentIsUpdatedAndRetrievedCorrectly(string updatedContentWithEscapableCharacters)
+    {
+        var connectionFactory = new TestingSqliteConnectionFactory();
+        using (var connection = connectionFactory.CreateOpenConnection())
+        {
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText = new FoodJournalNotesTableSchema().GetSQLTableCreationQuery();
+                command.ExecuteNonQuery();
+                
+                command.CommandText = "INSERT INTO food_journal_notes (id, date, content) VALUES " +
+                                      "(1, '2025-06-20', 'Original note content.')";
+                command.ExecuteNonQuery();
+            }
+        }
+        
+        var subject = new AcaiCore.FoodJournalNoteGateway(connectionFactory);
+        var result = subject.CreateOrUpdateNoteForDate(new DateTime(2025, 6, 20), updatedContentWithEscapableCharacters);
+        
+        Assert.That(result.GetContent(), Is.EqualTo(updatedContentWithEscapableCharacters));
+        Assert.That(result.GetID(), Is.EqualTo(1));
+        Assert.That(result.GetDate().Date, Is.EqualTo(new DateTime(2025, 6, 20).Date));
+    }
+}

--- a/Acai/AcaiCoreTests/FoodJournalNoteGateway/WhenCreateOrUpdateNoteForDateIsCalledMultipleTimesForTheSameDate.cs
+++ b/Acai/AcaiCoreTests/FoodJournalNoteGateway/WhenCreateOrUpdateNoteForDateIsCalledMultipleTimesForTheSameDate.cs
@@ -1,0 +1,70 @@
+using AcaiCore;
+using NUnit.Framework;
+
+namespace AcaiCoreTests.FoodJournalNoteGateway;
+
+[TestFixture]
+public class WhenCreateOrUpdateNoteForDateIsCalledMultipleTimesForTheSameDate
+{
+    private FoodJournalNoteDTO _firstResult;
+    private FoodJournalNoteDTO _secondResult;
+    private FoodJournalNoteDTO _thirdResult;
+
+    [OneTimeSetUp]
+    public void Setup()
+    {
+        var connectionFactory = new TestingSqliteConnectionFactory();
+        using (var connection = connectionFactory.CreateOpenConnection())
+        {
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText = new FoodJournalNotesTableSchema().GetSQLTableCreationQuery();
+                command.ExecuteNonQuery();
+            }
+        }
+        
+        var subject = new AcaiCore.FoodJournalNoteGateway(connectionFactory);
+        
+        _firstResult = subject.CreateOrUpdateNoteForDate(new DateTime(2025, 6, 20), "First note content");
+        _secondResult = subject.CreateOrUpdateNoteForDate(new DateTime(2025, 6, 20), "Second note content - updated");
+        _thirdResult = subject.CreateOrUpdateNoteForDate(new DateTime(2025, 6, 20), "Third and final note content - updated again");
+    }
+
+    [Test]
+    public void ThenAllCallsReturnTheSameID()
+    {
+        Assert.That(_firstResult.GetID(), Is.EqualTo(_secondResult.GetID()));
+        Assert.That(_secondResult.GetID(), Is.EqualTo(_thirdResult.GetID()));
+    }
+    
+    [Test]
+    public void ThenTheContentIsUpdatedEachTime()
+    {
+        Assert.That(_firstResult.GetContent(), Is.EqualTo("First note content"));
+        Assert.That(_secondResult.GetContent(), Is.EqualTo("Second note content - updated"));
+        Assert.That(_thirdResult.GetContent(), Is.EqualTo("Third and final note content - updated again"));
+    }
+
+    [Test]
+    public void ThenAllCallsReturnTheSameDate()
+    {
+        Assert.That(_firstResult.GetDate().Date, Is.EqualTo(new DateTime(2025, 6, 20).Date));
+        Assert.That(_secondResult.GetDate().Date, Is.EqualTo(new DateTime(2025, 6, 20).Date));
+        Assert.That(_thirdResult.GetDate().Date, Is.EqualTo(new DateTime(2025, 6, 20).Date));
+    }
+
+    [Test]
+    public void ThenOnlyOneRecordExistsInTheDatabase()
+    {
+        var connectionFactory = new TestingSqliteConnectionFactory();
+        using (var connection = connectionFactory.CreateOpenConnection())
+        {
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText = "SELECT COUNT(*) FROM food_journal_notes WHERE date(date) = date('2025-06-20')";
+                var count = (long)command.ExecuteScalar();
+                Assert.That(count, Is.EqualTo(1));
+            }
+        }
+    }
+}

--- a/Acai/AcaiCoreTests/FoodJournalNoteGateway/WhenCreateOrUpdateNoteForDateIsCalledMultipleTimesForTheSameDate.cs
+++ b/Acai/AcaiCoreTests/FoodJournalNoteGateway/WhenCreateOrUpdateNoteForDateIsCalledMultipleTimesForTheSameDate.cs
@@ -9,12 +9,14 @@ public class WhenCreateOrUpdateNoteForDateIsCalledMultipleTimesForTheSameDate
     private FoodJournalNoteDTO _firstResult;
     private FoodJournalNoteDTO _secondResult;
     private FoodJournalNoteDTO _thirdResult;
+    
+    private TestingSqliteConnectionFactory _connectionFactory;
 
     [OneTimeSetUp]
     public void Setup()
     {
-        var connectionFactory = new TestingSqliteConnectionFactory();
-        using (var connection = connectionFactory.CreateOpenConnection())
+        _connectionFactory = new TestingSqliteConnectionFactory();
+        using (var connection = _connectionFactory.CreateOpenConnection())
         {
             using (var command = connection.CreateCommand())
             {
@@ -23,7 +25,7 @@ public class WhenCreateOrUpdateNoteForDateIsCalledMultipleTimesForTheSameDate
             }
         }
         
-        var subject = new AcaiCore.FoodJournalNoteGateway(connectionFactory);
+        var subject = new AcaiCore.FoodJournalNoteGateway(_connectionFactory);
         
         _firstResult = subject.CreateOrUpdateNoteForDate(new DateTime(2025, 6, 20), "First note content");
         _secondResult = subject.CreateOrUpdateNoteForDate(new DateTime(2025, 6, 20), "Second note content - updated");
@@ -56,8 +58,7 @@ public class WhenCreateOrUpdateNoteForDateIsCalledMultipleTimesForTheSameDate
     [Test]
     public void ThenOnlyOneRecordExistsInTheDatabase()
     {
-        var connectionFactory = new TestingSqliteConnectionFactory();
-        using (var connection = connectionFactory.CreateOpenConnection())
+        using (var connection = _connectionFactory.CreateOpenConnection())
         {
             using (var command = connection.CreateCommand())
             {

--- a/Acai/AcaiCoreTests/FoodJournalNoteGateway/WhenCreateOrUpdateNoteForDateIsCalledWithEmptyContent.cs
+++ b/Acai/AcaiCoreTests/FoodJournalNoteGateway/WhenCreateOrUpdateNoteForDateIsCalledWithEmptyContent.cs
@@ -1,0 +1,45 @@
+using AcaiCore;
+using NUnit.Framework;
+
+namespace AcaiCoreTests.FoodJournalNoteGateway;
+
+[TestFixture]
+public class WhenCreateOrUpdateNoteForDateIsCalledWithEmptyContent
+{
+    private FoodJournalNoteDTO _result;
+
+    [OneTimeSetUp]
+    public void Setup()
+    {
+        var connectionFactory = new TestingSqliteConnectionFactory();
+        using (var connection = connectionFactory.CreateOpenConnection())
+        {
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText = new FoodJournalNotesTableSchema().GetSQLTableCreationQuery();
+                command.ExecuteNonQuery();
+            }
+        }
+        
+        var subject = new AcaiCore.FoodJournalNoteGateway(connectionFactory);
+        _result = subject.CreateOrUpdateNoteForDate(new DateTime(2025, 6, 20), string.Empty);
+    }
+
+    [Test]
+    public void ThenAnIDForTheNoteIsReturned()
+    {
+        Assert.That(_result.GetID(), Is.EqualTo(1));
+    }
+    
+    [Test]
+    public void ThenEmptyContentIsReturned()
+    {
+        Assert.That(_result.GetContent(), Is.EqualTo(string.Empty));
+    }
+
+    [Test]
+    public void ThenTheCorrectDateIsReturned()
+    {
+        Assert.That(_result.GetDate().Date, Is.EqualTo(new DateTime(2025, 6, 20).Date));
+    }
+}

--- a/Acai/AcaiCoreTests/JournalTableSchemas/FoodJournalNotesTableSchema/WhenAConnectionContainingTheCurrentFoodJournalNotesTableSchemaIsValidated.cs
+++ b/Acai/AcaiCoreTests/JournalTableSchemas/FoodJournalNotesTableSchema/WhenAConnectionContainingTheCurrentFoodJournalNotesTableSchemaIsValidated.cs
@@ -1,0 +1,35 @@
+using AcaiCore;
+using NUnit.Framework;
+
+namespace AcaiCoreTests.JournalTableSchemas.FoodJournalNotesTableSchema
+{
+    [TestFixture]
+    public class WhenAConnectionContainingTheCurrentFoodJournalNotesTableSchemaIsValidated
+    {
+        bool _result = false;
+
+        [OneTimeSetUp]
+        public void Setup()
+        {
+            var connectionFactory = new TestingSqliteConnectionFactory();
+            var subject = new AcaiCore.FoodJournalNotesTableSchema();
+
+            using (var connection = connectionFactory.CreateOpenConnection())
+            {
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText = "CREATE TABLE \"food_journal_notes\" (\"id\" INTEGER NOT NULL UNIQUE,\"date\" TEXT NOT NULL UNIQUE,\"content\" TEXT NOT NULL, PRIMARY KEY(\"id\" AUTOINCREMENT))";
+                    command.ExecuteNonQuery();
+                }
+
+                _result = subject.PresentInConnection(connection);
+            }
+        }
+
+        [Test]
+        public void ThenTheExpectedOutcomeIsTrue()
+        {
+            Assert.That(_result, Is.True);
+        }
+    }
+}

--- a/Acai/AcaiCoreTests/JournalTableSchemas/FoodJournalNotesTableSchema/WhenAConnectionWithoutTheCurrentFoodJournalNotesTableSchemaIsValidated.cs
+++ b/Acai/AcaiCoreTests/JournalTableSchemas/FoodJournalNotesTableSchema/WhenAConnectionWithoutTheCurrentFoodJournalNotesTableSchemaIsValidated.cs
@@ -1,0 +1,29 @@
+using AcaiCore;
+using NUnit.Framework;
+
+namespace AcaiCoreTests.JournalTableSchemas.FoodJournalNotesTableSchema
+{
+    [TestFixture]
+    public class WhenAConnectionWithoutTheCurrentFoodJournalNotesTableSchemaIsValidated
+    {
+        bool _result = false;
+
+        [OneTimeSetUp]
+        public void Setup()
+        {
+            var connectionFactory = new TestingSqliteConnectionFactory();
+            var subject = new AcaiCore.FoodJournalNotesTableSchema();
+
+            using (var connection = connectionFactory.CreateOpenConnection())
+            {
+                _result = subject.PresentInConnection(connection);
+            }
+        }
+
+        [Test]
+        public void ThenTheExpectedOutcomeIsFalse()
+        {
+            Assert.That(_result, Is.False);
+        }
+    }
+}

--- a/Acai/AcaiCoreTests/JournalTableSchemas/FoodJournalNotesTableSchema/WhenTheSQLCreationQueryOfTheFoodJournalNotesTableIsRequested.cs
+++ b/Acai/AcaiCoreTests/JournalTableSchemas/FoodJournalNotesTableSchema/WhenTheSQLCreationQueryOfTheFoodJournalNotesTableIsRequested.cs
@@ -1,0 +1,23 @@
+using NUnit.Framework;
+
+namespace AcaiCoreTests.JournalTableSchemas.FoodJournalNotesTableSchema
+{
+    [TestFixture]
+    public class WhenTheSQLCreationQueryOfTheFoodJournalNotesTableIsRequested
+    {
+        string _result;
+        
+        [OneTimeSetUp]
+        public void Setup()
+        {
+            var subject = new AcaiCore.FoodJournalNotesTableSchema();
+            _result = subject.GetSQLTableCreationQuery();
+        }
+
+        [Test]
+        public void ThenTheCorrectQueryStringIsReturned()
+        {
+            Assert.That(_result, Is.EqualTo("CREATE TABLE \"food_journal_notes\" (\"id\" INTEGER NOT NULL UNIQUE,\"date\" TEXT NOT NULL UNIQUE,\"content\" TEXT NOT NULL, PRIMARY KEY(\"id\" AUTOINCREMENT))"));
+        }
+    }
+}

--- a/Acai/AcaiMobile/ContentViews/NoteCard/NoteCard.xaml
+++ b/Acai/AcaiMobile/ContentViews/NoteCard/NoteCard.xaml
@@ -2,34 +2,19 @@
 
 <ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="AcaiMobile.ContentViews.NoteCard">
+             x:Class="AcaiMobile.ContentViews.NoteCard"
+             xmlns:local="clr-namespace:AcaiMobile.ContentViews"
+             x:DataType="local:NoteCard"
+             x:Name="NoteCardRoot">
     <Frame Margin="10,5" BackgroundColor="LightGoldenrodYellow">
-        <StackLayout>
-            <Label>
-                <Label.FormattedText>
-                    <FormattedString>
-                        <Span Text="This is a piece of "/>
-                        <Span Text="bold" FontAttributes="Bold"/>
-                        <Span Text=" and "/>
-                        <Span Text="italic-bold" FontAttributes="Italic,Bold"/>
-                        <Span Text=" text."/>
-                    </FormattedString>
-                </Label.FormattedText>
-            </Label>
-            
-            <Label></Label>
-            
-            <Label>
-                <Label.FormattedText>
-                    <FormattedString>
-                        <Span Text="This is another piece of "/>
-                        <Span Text="bold" FontAttributes="Bold"/>
-                        <Span Text=" and "/>
-                        <Span Text="italic-bold" FontAttributes="Italic,Bold"/>
-                        <Span Text=" text."/>
-                    </FormattedString>
-                </Label.FormattedText>
-            </Label>
+        <StackLayout BindingContext="{Reference NoteCardRoot}">
+            <CollectionView ItemsSource="{Binding FormattedContentLabels}">
+                <CollectionView.ItemTemplate>
+                    <DataTemplate x:DataType="Label">
+                        <Label FormattedText="{Binding FormattedText}" FontAttributes="{Binding FontAttributes}"></Label>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
         </StackLayout>
     </Frame>
 </ContentView>

--- a/Acai/AcaiMobile/ContentViews/NoteCard/NoteCard.xaml
+++ b/Acai/AcaiMobile/ContentViews/NoteCard/NoteCard.xaml
@@ -2,7 +2,7 @@
 <ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="AcaiMobile.ContentViews.NoteCard">
-    <Frame Margin="10,5" BackgroundColor="LightGoldenrodYellow">
+    <Frame Style="{StaticResource NoteCard}">
         <StackLayout>
             <CollectionView x:Name="FormattedLabels">
                 <CollectionView.ItemTemplate>

--- a/Acai/AcaiMobile/ContentViews/NoteCard/NoteCard.xaml
+++ b/Acai/AcaiMobile/ContentViews/NoteCard/NoteCard.xaml
@@ -1,0 +1,35 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="AcaiMobile.ContentViews.NoteCard">
+    <Frame Margin="10,5" BackgroundColor="LightGoldenrodYellow">
+        <StackLayout>
+            <Label>
+                <Label.FormattedText>
+                    <FormattedString>
+                        <Span Text="This is a piece of "/>
+                        <Span Text="bold" FontAttributes="Bold"/>
+                        <Span Text=" and "/>
+                        <Span Text="italic-bold" FontAttributes="Italic,Bold"/>
+                        <Span Text=" text."/>
+                    </FormattedString>
+                </Label.FormattedText>
+            </Label>
+            
+            <Label></Label>
+            
+            <Label>
+                <Label.FormattedText>
+                    <FormattedString>
+                        <Span Text="This is another piece of "/>
+                        <Span Text="bold" FontAttributes="Bold"/>
+                        <Span Text=" and "/>
+                        <Span Text="italic-bold" FontAttributes="Italic,Bold"/>
+                        <Span Text=" text."/>
+                    </FormattedString>
+                </Label.FormattedText>
+            </Label>
+        </StackLayout>
+    </Frame>
+</ContentView>

--- a/Acai/AcaiMobile/ContentViews/NoteCard/NoteCard.xaml
+++ b/Acai/AcaiMobile/ContentViews/NoteCard/NoteCard.xaml
@@ -1,14 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-
+<?xml version="1.0" encoding="utf-8"?>
 <ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="AcaiMobile.ContentViews.NoteCard"
-             xmlns:local="clr-namespace:AcaiMobile.ContentViews"
-             x:DataType="local:NoteCard"
-             x:Name="NoteCardRoot">
+             x:Class="AcaiMobile.ContentViews.NoteCard">
     <Frame Margin="10,5" BackgroundColor="LightGoldenrodYellow">
-        <StackLayout BindingContext="{Reference NoteCardRoot}">
-            <CollectionView ItemsSource="{Binding FormattedContentLabels}">
+        <StackLayout>
+            <CollectionView x:Name="FormattedLabels">
                 <CollectionView.ItemTemplate>
                     <DataTemplate x:DataType="Label">
                         <Label FormattedText="{Binding FormattedText}" FontAttributes="{Binding FontAttributes}"></Label>

--- a/Acai/AcaiMobile/ContentViews/NoteCard/NoteCard.xaml.cs
+++ b/Acai/AcaiMobile/ContentViews/NoteCard/NoteCard.xaml.cs
@@ -1,0 +1,9 @@
+﻿namespace AcaiMobile.ContentViews;
+
+public partial class NoteCard : ContentView
+{
+    public NoteCard()
+    {
+        InitializeComponent();
+    }
+}

--- a/Acai/AcaiMobile/ContentViews/NoteCard/NoteCard.xaml.cs
+++ b/Acai/AcaiMobile/ContentViews/NoteCard/NoteCard.xaml.cs
@@ -2,6 +2,79 @@
 
 public partial class NoteCard : ContentView
 {
+    private readonly BindableProperty _contentProperty = BindableProperty.Create(nameof(Content), typeof(string), typeof(NoteCard), string.Empty);
+    private readonly BindableProperty _formattedContentLabelsProperty = BindableProperty.Create(nameof(FormattedContentLabels), typeof(List<Label>), typeof(NoteCard), new List<Label>());
+    
+    public string Content
+    {
+        set => TokenizeAndFormatContent(value);
+    }
+
+    public List<Label> FormattedContentLabels
+    {
+        get => (List<Label>)GetValue(_formattedContentLabelsProperty);
+    }
+
+    private void TokenizeAndFormatContent(string value)
+    {
+        bool useBoldFormatting = false;
+        bool useItalicFormatting = false;
+        
+        foreach (var line in value.Split("\\n"))
+        {
+            var label = new Label()
+            {
+                FormattedText = new FormattedString()
+                {
+                    Spans = { }
+                }
+            };
+
+            foreach (var token in line.Split(" "))
+            {
+                var word = token;
+                FontAttributes tokenFormatting = FontAttributes.None;
+
+                bool charactersInWordOnlyContainAsteriskLiterals = word.Replace("*","").Length == 0;
+
+                if (!charactersInWordOnlyContainAsteriskLiterals)
+                {
+                    if (word.StartsWith("**"))
+                    {
+                        word = word.Substring(2);
+                        useBoldFormatting = !useBoldFormatting;
+                    }
+
+                    if (word.StartsWith("*"))
+                    {
+                        word = word.Substring(1);
+                        useItalicFormatting = !useItalicFormatting;
+                    }
+                }
+
+                tokenFormatting = tokenFormatting | (useBoldFormatting ? FontAttributes.Bold : FontAttributes.None) | (useItalicFormatting ? FontAttributes.Italic : FontAttributes.None);
+                
+                if (!charactersInWordOnlyContainAsteriskLiterals) { 
+                    if (word.EndsWith("**"))
+                    {
+                        word = word.Substring(0, word.Length - 2);
+                        useBoldFormatting = !useBoldFormatting;
+                    }
+                    if (word.EndsWith("*"))
+                    {
+                        word = word.Substring(0, word.Length - 1);
+                        useItalicFormatting = !useItalicFormatting;
+                    }
+                }
+                
+                label.FormattedText.Spans.Insert(label.FormattedText.Spans.Count, new Span(){ Text = $"{word} ", FontAttributes = tokenFormatting });
+            }
+            
+            FormattedContentLabels.Insert(FormattedContentLabels.Count, label);
+        }
+        SetValue(_contentProperty, value);
+    }
+    
     public NoteCard()
     {
         InitializeComponent();

--- a/Acai/AcaiMobile/ContentViews/NoteCard/NoteCard.xaml.cs
+++ b/Acai/AcaiMobile/ContentViews/NoteCard/NoteCard.xaml.cs
@@ -1,22 +1,32 @@
-﻿namespace AcaiMobile.ContentViews;
+namespace AcaiMobile.ContentViews;
 
 public partial class NoteCard : ContentView
 {
-    private readonly BindableProperty _contentProperty = BindableProperty.Create(nameof(Content), typeof(string), typeof(NoteCard), string.Empty);
-    private readonly BindableProperty _formattedContentLabelsProperty = BindableProperty.Create(nameof(FormattedContentLabels), typeof(List<Label>), typeof(NoteCard), new List<Label>());
+    public static readonly BindableProperty NoteContentProperty = BindableProperty.Create(nameof(NoteContent), typeof(string), typeof(NoteCard), string.Empty, propertyChanged: OnNoteContentChanged);
     
-    public string Content
+    public string NoteContent
     {
-        set => TokenizeAndFormatContent(value);
+        get => (string)GetValue(NoteContentProperty);
+        set => SetValue(NoteContentProperty, value);
+    }
+    
+    private static void OnNoteContentChanged(BindableObject bindable, object oldValue, object newValue)
+    {
+        if (bindable is NoteCard)
+        {
+            ((NoteCard)bindable).FormattedLabels.ItemsSource = TokenizeAndFormatContent(newValue?.ToString());
+        }
     }
 
-    public List<Label> FormattedContentLabels
+    private static List<Label> TokenizeAndFormatContent(string value)
     {
-        get => (List<Label>)GetValue(_formattedContentLabelsProperty);
-    }
+        var formattedContentLabels = new List<Label>();
 
-    private void TokenizeAndFormatContent(string value)
-    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return formattedContentLabels;
+        }
+        
         bool useBoldFormatting = false;
         bool useItalicFormatting = false;
         
@@ -70,9 +80,10 @@ public partial class NoteCard : ContentView
                 label.FormattedText.Spans.Insert(label.FormattedText.Spans.Count, new Span(){ Text = $"{word} ", FontAttributes = tokenFormatting });
             }
             
-            FormattedContentLabels.Insert(FormattedContentLabels.Count, label);
+            formattedContentLabels.Insert(formattedContentLabels.Count, label);
         }
-        SetValue(_contentProperty, value);
+
+        return formattedContentLabels;
     }
     
     public NoteCard()

--- a/Acai/AcaiMobile/Pages/FoodJournalPage/FoodJournalPage.xaml
+++ b/Acai/AcaiMobile/Pages/FoodJournalPage/FoodJournalPage.xaml
@@ -27,11 +27,7 @@
             <RowDefinition Height="1*"></RowDefinition>
         </Grid.RowDefinitions>
 
-        <!-- TODO: This is not actually binding to the Note / updating in real time -->
-        <!-- <contentViews:NoteCard Grid.Row="1" Content="{Binding Note}" IsVisible="{Binding DisplayNote}"/> -->
-        <Frame Margin="10,5" BackgroundColor="LightGoldenrodYellow" Grid.Row="1" IsVisible="{Binding DisplayNote}">
-            <Label Text="{Binding Note}"></Label>
-        </Frame>
+        <contentViews:NoteCard Grid.Row="1" NoteContent="{Binding Note}" IsVisible="{Binding DisplayNote}"/>
         
         <Grid Grid.Row="0">
             <Grid.ColumnDefinitions>

--- a/Acai/AcaiMobile/Pages/FoodJournalPage/FoodJournalPage.xaml
+++ b/Acai/AcaiMobile/Pages/FoodJournalPage/FoodJournalPage.xaml
@@ -2,6 +2,7 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+             xmlns:contentViews="clr-namespace:AcaiMobile.ContentViews"
              x:Class="AcaiMobile.FoodJournalPage"
              Title="Food Journal"
 
@@ -16,11 +17,14 @@
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"></RowDefinition>
+            <RowDefinition Height="Auto"></RowDefinition>
             <RowDefinition Height="8*"></RowDefinition>
             <RowDefinition Height=".75*"></RowDefinition>
             <RowDefinition Height="1*"></RowDefinition>
         </Grid.RowDefinitions>
 
+        <contentViews:NoteCard Grid.Row="1"></contentViews:NoteCard>
+        
         <Grid Grid.Row="0">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="1*"></ColumnDefinition>
@@ -32,10 +36,10 @@
             <Button Grid.Column="2" Style="{StaticResource Main}" Margin="0,10,10,10" FontSize="24" Text="+" Command="{Binding ProgressSelectedDateByNumberOfDaysCommand}" CommandParameter="1"/>
         </Grid>
 
-            <ScrollView Grid.Row="1">
+            <ScrollView Grid.Row="2">
             <VerticalStackLayout
                 Spacing="5"
-                Padding="10,10">
+                Padding="10,0">
                 <CollectionView ItemsSource="{Binding FoodItemsList}">
                     <CollectionView.ItemTemplate>
                         <DataTemplate x:DataType="{x:Type acaiMobile:FoodJournalViewItem}">
@@ -131,7 +135,7 @@
             </VerticalStackLayout>
         </ScrollView>
 
-        <Label Grid.Row="2" HorizontalTextAlignment="Center" Margin="10" VerticalTextAlignment="Center">
+        <Label Grid.Row="3" HorizontalTextAlignment="Center" Margin="10" VerticalTextAlignment="Center">
             <Label.Text>
                 <MultiBinding StringFormat="Total: {0} / {1} kcal">
                     <Binding Path="TotalCalories" />
@@ -141,7 +145,7 @@
         </Label>
 
         <Button
-            Grid.Row="3"
+            Grid.Row="4"
             Style="{StaticResource Main}"
             Text="Add new Item"
             Margin="10,0,10,10"

--- a/Acai/AcaiMobile/Pages/FoodJournalPage/FoodJournalPage.xaml
+++ b/Acai/AcaiMobile/Pages/FoodJournalPage/FoodJournalPage.xaml
@@ -15,7 +15,7 @@
     </ContentPage.Behaviors>
     
     <ContentPage.ToolbarItems>
-        <ToolbarItem Order="Secondary" Text="Edit Note"></ToolbarItem>
+        <ToolbarItem Order="Secondary" Text="Edit Note" Command="{Binding EditNoteCommand}"></ToolbarItem>
     </ContentPage.ToolbarItems>
     
     <Grid>
@@ -27,7 +27,11 @@
             <RowDefinition Height="1*"></RowDefinition>
         </Grid.RowDefinitions>
 
-        <contentViews:NoteCard Grid.Row="1" Content="📝 This is **bold** and this is *italic* for basic formatting tests.\n\nHere we have ***bold-and-italic (with a literal set of *** asterisks *** here)*** which should render with both styles applied."/>
+        <!-- TODO: This is not actually binding to the Note / updating in real time -->
+        <!-- <contentViews:NoteCard Grid.Row="1" Content="{Binding Note}" IsVisible="{Binding DisplayNote}"/> -->
+        <Frame Margin="10,5" BackgroundColor="LightGoldenrodYellow" Grid.Row="1" IsVisible="{Binding DisplayNote}">
+            <Label Text="{Binding Note}"></Label>
+        </Frame>
         
         <Grid Grid.Row="0">
             <Grid.ColumnDefinitions>

--- a/Acai/AcaiMobile/Pages/FoodJournalPage/FoodJournalPage.xaml
+++ b/Acai/AcaiMobile/Pages/FoodJournalPage/FoodJournalPage.xaml
@@ -14,6 +14,10 @@
         <toolkit:EventToCommandBehavior EventName="Appearing" Command="{Binding PageAppearCommand}"></toolkit:EventToCommandBehavior>
     </ContentPage.Behaviors>
     
+    <ContentPage.ToolbarItems>
+        <ToolbarItem Order="Secondary" Text="Edit Note"></ToolbarItem>
+    </ContentPage.ToolbarItems>
+    
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"></RowDefinition>

--- a/Acai/AcaiMobile/Pages/FoodJournalPage/FoodJournalPage.xaml
+++ b/Acai/AcaiMobile/Pages/FoodJournalPage/FoodJournalPage.xaml
@@ -23,7 +23,7 @@
             <RowDefinition Height="1*"></RowDefinition>
         </Grid.RowDefinitions>
 
-        <contentViews:NoteCard Grid.Row="1"></contentViews:NoteCard>
+        <contentViews:NoteCard Grid.Row="1" Content="📝 This is **bold** and this is *italic* for basic formatting tests.\n\nHere we have ***bold-and-italic (with a literal set of *** asterisks *** here)*** which should render with both styles applied."/>
         
         <Grid Grid.Row="0">
             <Grid.ColumnDefinitions>

--- a/Acai/AcaiMobile/Resources/Styles/Colors.xaml
+++ b/Acai/AcaiMobile/Resources/Styles/Colors.xaml
@@ -65,6 +65,11 @@
     <Color x:Key="Gray12Dark">#EEEEF0</Color>
     <!--  -->
     
+    <!-- Note Cards -->
+    <Color x:Key="CreamLight">#FAF5E4</Color>
+    <Color x:Key="CreamDark">#2A2418</Color>
+    <!-- -->
+    
     <Color x:Key="AcaiPurple">#7F2982</Color>
     
     <Color x:Key="Danger">#CC2936</Color>

--- a/Acai/AcaiMobile/Resources/Styles/Styles.xaml
+++ b/Acai/AcaiMobile/Resources/Styles/Styles.xaml
@@ -133,6 +133,15 @@
         <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Gray1Light}, Dark={StaticResource Gray3Dark}}" />
     </Style>
     
+    <Style x:Key="NoteCard" TargetType="Frame">
+        <Setter Property="HasShadow" Value="False" />
+        <Setter Property="BorderColor" Value="{AppThemeBinding Light={StaticResource Gray6Light}, Dark={StaticResource Gray6Dark}}" />
+        <Setter Property="CornerRadius" Value="8"/>
+        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource CreamLight}, Dark={StaticResource CreamDark}}" />
+        <Setter Property="Margin" Value="10,5" />
+    </Style>
+    
+    
     <Style TargetType="Label">
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}" />
         <Setter Property="FontFamily" Value="OpenSansRegular" />


### PR DESCRIPTION
This PR introduces the ability for users to edit and display an optional free-text note on any given day within the Food Journal Page in order to provide additional context or reminders to themselves. A minimal amount of rudimentary formatting can also be applied to notes when displayed in-app by wrapping text in single or double asterisks (`*`) for italic or bold text; similar to Markdown.