### PR TITLE
AcaiMobile: Hotfix for GitHub Version checking by switching to VersionString.

### DIFF
--- a/Acai/AcaiMobile/GithubReleaseRetriever.cs
+++ b/Acai/AcaiMobile/GithubReleaseRetriever.cs
@@ -40,7 +40,8 @@ public class GithubReleaseRetriever : IReleaseRetriever
     private bool ReleaseHasNewerVersion(GithubReleaseResponseItem release)
     {
         var releaseVersion = Version.Parse(release.Version.ToLower().Replace("v",""));
-        return releaseVersion.Major > AppInfo.Version.Major || releaseVersion.Minor > AppInfo.Version.Minor || releaseVersion.Build > AppInfo.Version.Build;
+        var currentVersion = Version.Parse(AppInfo.VersionString.ToLower().Replace("v",""));
+        return releaseVersion.Major > currentVersion.Major || releaseVersion.Minor > currentVersion.Minor || releaseVersion.Build > currentVersion.Build;
     }
 
     private async Task<GithubReleaseResponseItem> GetMostRecentRelease()


### PR DESCRIPTION
There is a bug in AcaiMobile where a User is notified of a new Release despite being on the latest version already. This ultimately is down the use of `AppInfo.Version` when comparing the current app version to the latest one found in Github Releases. This always resolves to `0.0`, causing version number checks to always pass. 

For the sake of consistency and to make it easier to reason about against the fact that Version String for builds are set in Github Actions, the current version of the app is derived from parsing this instead when checking for updates, which should resolve this issue.