### PR TITLE
Added total sum displays for enabled Macronutrients on Food Journal Page

### DIFF
--- a/Acai/AcaiMobile/Pages/FoodJournalPage/FoodJournalPage.xaml
+++ b/Acai/AcaiMobile/Pages/FoodJournalPage/FoodJournalPage.xaml
@@ -39,7 +39,7 @@
             <Button Grid.Column="2" Style="{StaticResource Main}" Margin="0,10,10,10" FontSize="24" Text="+" Command="{Binding ProgressSelectedDateByNumberOfDaysCommand}" CommandParameter="1"/>
         </Grid>
 
-            <ScrollView Grid.Row="2">
+        <ScrollView Grid.Row="2">
             <VerticalStackLayout
                 Spacing="5"
                 Padding="10,0">
@@ -135,17 +135,54 @@
                         </DataTemplate>
                     </CollectionView.ItemTemplate>
                 </CollectionView>
+                    <VerticalStackLayout>
+                        <Label HorizontalTextAlignment="Center" VerticalTextAlignment="Center" Text="Summary" FontAttributes="Bold"/>
+                        <Label HorizontalTextAlignment="Center" VerticalTextAlignment="Center">
+                            <Label.Text>
+                                <MultiBinding StringFormat="Calories: {0} / {1}kcal">
+                                    <Binding Path="TotalCalories" />
+                                    <Binding Path="CaloricLimit" />
+                                </MultiBinding>
+                            </Label.Text>
+                        </Label>
+                        <Label HorizontalTextAlignment="Center" VerticalTextAlignment="Center" IsVisible="{Binding Source={x:Reference FoodJournalViewModelRoot}, Path=BindingContext.DisplayItemProtein}">
+                            <Label.Text>
+                                <MultiBinding StringFormat="Protein: {0}g">
+                                    <Binding Path="TotalProtein" />
+                                </MultiBinding>
+                            </Label.Text>
+                        </Label>
+                        <Label HorizontalTextAlignment="Center" VerticalTextAlignment="Center" IsVisible="{Binding Source={x:Reference FoodJournalViewModelRoot}, Path=BindingContext.DisplayItemCarbohydrates}">
+                            <Label.Text>
+                                <MultiBinding StringFormat="Carbohydrates: {0}g">
+                                    <Binding Path="TotalCarbohydrates" />
+                                </MultiBinding>
+                            </Label.Text>
+                        </Label>
+                        <Label HorizontalTextAlignment="Center" VerticalTextAlignment="Center" IsVisible="{Binding Source={x:Reference FoodJournalViewModelRoot}, Path=BindingContext.DisplayItemFat}">
+                            <Label.Text>
+                                <MultiBinding StringFormat="Fat: {0}g">
+                                    <Binding Path="TotalFat" />
+                                </MultiBinding>
+                            </Label.Text>
+                        </Label>
+                        <Label HorizontalTextAlignment="Center" VerticalTextAlignment="Center" IsVisible="{Binding Source={x:Reference FoodJournalViewModelRoot}, Path=BindingContext.DisplayItemFibre}">
+                            <Label.Text>
+                                <MultiBinding StringFormat="Fibre: {0}g">
+                                    <Binding Path="TotalFibre" />
+                                </MultiBinding>
+                            </Label.Text>
+                        </Label>
+                        <Label HorizontalTextAlignment="Center" VerticalTextAlignment="Center" IsVisible="{Binding Source={x:Reference FoodJournalViewModelRoot}, Path=BindingContext.DisplayItemWater}">
+                            <Label.Text>
+                                <MultiBinding StringFormat="Water: {0}ml">
+                                    <Binding Path="TotalWater" />
+                                </MultiBinding>
+                            </Label.Text>
+                        </Label>
+                    </VerticalStackLayout>
             </VerticalStackLayout>
         </ScrollView>
-
-        <Label Grid.Row="3" HorizontalTextAlignment="Center" Margin="10" VerticalTextAlignment="Center">
-            <Label.Text>
-                <MultiBinding StringFormat="Total: {0} / {1} kcal">
-                    <Binding Path="TotalCalories" />
-                    <Binding Path="CaloricLimit" />
-                </MultiBinding>
-            </Label.Text>
-        </Label>
 
         <!-- Floating Action Button -->
         <ImageButton

--- a/Acai/AcaiMobile/Pages/FoodJournalPage/FoodJournalViewModel.cs
+++ b/Acai/AcaiMobile/Pages/FoodJournalPage/FoodJournalViewModel.cs
@@ -36,6 +36,16 @@ public partial class FoodJournalViewModel : ObservableObject
     private float _totalCalories = 0;
     [ObservableProperty] 
     private float _caloricLimit = 0;
+    [ObservableProperty]
+    private float? _totalProtein = 0;
+    [ObservableProperty]
+    private float? _totalCarbohydrates = 0;
+    [ObservableProperty]
+    private float? _totalFat = 0;
+    [ObservableProperty]
+    private float? _totalFibre = 0;
+    [ObservableProperty]
+    private float? _totalWater = 0;
     
     [ObservableProperty]
     private bool _displayItemProtein = false;
@@ -177,7 +187,7 @@ public partial class FoodJournalViewModel : ObservableObject
             session.GetFoodItemGateway().DeleteFoodItem(itemPendingDeletion.Id);
             _foodItemsList.Remove(itemPendingDeletion);
         }
-        UpdateTotalCalories();
+        UpdateTotalValues();
     }
 
     [RelayCommand]
@@ -245,12 +255,17 @@ public partial class FoodJournalViewModel : ObservableObject
         {
             _foodItemsList.Add(new FoodJournalViewItem(foodItem));
         }
-        UpdateTotalCalories();
+        UpdateTotalValues();
     }
     
-    private void UpdateTotalCalories()
+    private void UpdateTotalValues()
     {
         TotalCalories = _foodItemsList.Sum(x => x.Calories);
+        TotalProtein = _foodItemsList.Sum(x => x.Protein);
+        TotalCarbohydrates = _foodItemsList.Sum(x => x.Carbohydrates);
+        TotalFat = _foodItemsList.Sum(x => x.Fat);
+        TotalFibre = _foodItemsList.Sum(x => x.Fibre);
+        TotalWater = _foodItemsList.Sum(x => x.Water);
     }
     
 }


### PR DESCRIPTION
This PR adds additional labels to the Food Journal Page which display a total combined value for that day's list of items for every Macronutrient that can be recorded. This is displayed alongside the total caloric counter which was already there.

Keeping in line with the conventions established previously, these new total displays are hidden from the User's view if they have disabled that particular macronutrient in the Settings page of the app.